### PR TITLE
CORE-346: Fix secondary and cta props in commonsku-styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonsku/styles",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Common React components by commonsku",
   "author": "commonsku",
   "license": "ISC",

--- a/src/@commonsku/styles/Button.tsx
+++ b/src/@commonsku/styles/Button.tsx
@@ -381,7 +381,7 @@ const Button = styled.button<ButtonProps>`
       opacity: 0.5;
       ${p => getVariantStyles(p, 'disabled')}
     }
-    ${p => getVariantStyles(p, p.disabled ? 'disabled' : (p.variant ?? 'primary'))}
+    ${p => getVariantStyles(p, p.disabled ? 'disabled' : (p.variant ?? (secondary ? 'secondary' : (cta ? 'cta' : 'primary'))))}
     ${SharedStyles}
     ${SizerCss}
   }


### PR DESCRIPTION
This updates the Button component so that the variant reflects the `secondary` and `cta` props if it is not set explicitly.