### PR TITLE
Allow passing styles to fields with an icon on the right side 

### DIFF
--- a/src/@commonsku/styles/Input.tsx
+++ b/src/@commonsku/styles/Input.tsx
@@ -343,7 +343,7 @@ export const LabeledIconInput = React.forwardRef<HTMLInputElement, LabeledIconIn
             onBlur={onBlur}
           />
           {iconPosition === 'right' ? <InputIconLabel
-            style={{ marginBottom: 0, padding: 6, }}
+            style={{ marginBottom: 0, padding: 6, ...iconLabelStyles }}
             isActive={isActive}
             isDisabled={disabled}
             isHover={isHovering}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1324,6 +1324,20 @@ const App = () => {
                   style={{ width: 200 }}
                 />
 
+                <br />
+
+                <LabeledIconInput
+                  labelOnTop
+                  label='Labeled input'
+                  name="basic-input"
+                  defaultValue="input value"
+                  placeholder="Password"
+                  Icon={<Link>Forgot?</Link>}
+                  iconPosition='right'
+                  iconLabelStyles={{width:"auto", fontSize: 11, background: 'transparent', color: teal.main }}
+                  style={{ width: 200 }}
+                />
+
                 <LabeledIconInput
                   labelOnTop
                   disabled


### PR DESCRIPTION
Allow passing styles to fields with an icon on the right side. 

We'll then be able to place text links there, like the Forgot? link on password fields.