### PR TITLE
CORE-643: remove selectedTabIndex from div props

### DIFF
--- a/src/@commonsku/styles/Tabs.tsx
+++ b/src/@commonsku/styles/Tabs.tsx
@@ -143,7 +143,7 @@ class Tabs extends Component<TabsProps, TabsState> {
   }
 
   render () {
-    const { tabs, size, padded, variant, ...props } = this.props;
+    const { tabs, size, padded, variant, selectedTabIndex, ...props } = this.props;
     const selectedTab = this.getTab(tabs, this.state.selectedTabIndex);
     return <div {...props}>
       <TabBar padded={padded === true}>


### PR DESCRIPTION
This was causing an error in the console.