### PR TITLE
[QA-588] add className to DateRangeDropdown, adjust styles to allow long preset labels to grow

### DIFF
--- a/src/@commonsku/styles/DateRangeDropdown.tsx
+++ b/src/@commonsku/styles/DateRangeDropdown.tsx
@@ -140,6 +140,7 @@ export const DateRangeDropdown = (props: DateRangeDropdownProps) => {
     placeholder,
     placeholderText,
     style = dropdownStyles,
+    className,
   } = props;
   const [open, setOpen] = useState(false);
   const datepickerRef = useRef<HTMLDivElement | null>(null);
@@ -173,7 +174,7 @@ export const DateRangeDropdown = (props: DateRangeDropdownProps) => {
   }, [handleChange]);
 
   return (
-    <>
+    <div className={className}>
       <DateRangeInput
         noMargin
         value={
@@ -195,7 +196,7 @@ export const DateRangeDropdown = (props: DateRangeDropdownProps) => {
           onChange={handleChange}
         />
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/@commonsku/styles/DateRangePicker.tsx
+++ b/src/@commonsku/styles/DateRangePicker.tsx
@@ -44,6 +44,7 @@ const presetLabelStyles: CSSProperties = {
   flexBasis: "200px",
   justifyContent: "left",
   padding: "13px",
+  whiteSpace: "nowrap",
 };
 
 const dateRangeLabelStyles: CSSProperties = {

--- a/src/@commonsku/styles/DateRangePicker.tsx
+++ b/src/@commonsku/styles/DateRangePicker.tsx
@@ -40,11 +40,10 @@ const presetListStyles: CSSProperties = {
 
 const presetLabelStyles: CSSProperties = {
   margin: "0",
-  flexGrow: "1",
-  flexBasis: "200px",
+  flex: "1 0 200px",
+  minWidth: "fit-content",
   justifyContent: "left",
   padding: "13px",
-  whiteSpace: "nowrap",
 };
 
 const dateRangeLabelStyles: CSSProperties = {


### PR DESCRIPTION
Adding a `className` prop allows us to target this component with styled-components. Adding `min-width: fit-content` to the preset labels allows longer presets to fill up a full flex row.