### PR TITLE
[QA-585] Specify a max-width for Select dropdown menus

### DIFF
--- a/src/@commonsku/styles/Select/utils.ts
+++ b/src/@commonsku/styles/Select/utils.ts
@@ -144,6 +144,7 @@ export function skuSelectStyles<
         border: `1px solid ${borderColor}`,
         width: "max-content",
         minWidth: "100%",
+        maxWidth: "320px",
         boxShadow: `
           1px 1px 0px ${borderColor},
           -1px -1px 0px ${borderColor},


### PR DESCRIPTION
`min-width` has priority over `max-width`, so if the component exceeds 320px the menu will still be 100% of the width of the component.