### PR TITLE
feat(CORE-1136): Add Tooltip to Artwork Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can also check out the src/App.tsx to see how to import in your projects
 
 ### Testing locally with main repo
 
-You can add this into the `~/.bashrc` or `~/.profile`
+You can add this into the `~/.zshrc`
 
 Below code adds commnand `cskustyled` to build and install commonsku styles into your local project
 
@@ -35,6 +35,9 @@ CSKU_STYLES_DIR="$HOME/projects/commonsku-styles"
 function fn_cskustyled() {
   CSKUS_PKG_VERSION=$(cat $CSKU_STYLES_DIR/package.json 2>&1 | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
   touch $CSKU_STYLES_DIR/dist && rm -r $CSKU_STYLES_DIR/dist \
+    && cd $CSKU_DEV_DIR \
+        && rm -rf node_modules/ \
+        && npm cache clean --force \
     && touch $CSKU_STYLES_DIR/commonsku-styles-$CSKUS_PKG_VERSION.tgz && rm $CSKU_STYLES_DIR/commonsku-styles-$CSKUS_PKG_VERSION.tgz \
     && touch $CSKU_DEV_DIR/commonsku-styles-$CSKUS_PKG_VERSION.tgz && rm $CSKU_DEV_DIR/commonsku-styles-$CSKUS_PKG_VERSION.tgz \
     && cd $CSKU_STYLES_DIR \

--- a/src/@commonsku/styles/Artwork.tsx
+++ b/src/@commonsku/styles/Artwork.tsx
@@ -6,6 +6,7 @@ import {Input, InputProps} from './Input'
 import {IconDoc, DownloadIcon} from './icons'
 import { getThemeColor, getThemeFontSize, colors } from './Theme';
 import { SharedStyles, SharedStyleTypes } from './SharedStyles';
+import { Tooltip } from 'react-tooltip';
 
 
 const ArtworkName = styled.div`
@@ -77,6 +78,17 @@ const ArtworkPicture = styled.div<{cssHeight:number} >`
     opacity: 1;
   }
 `
+
+const ArtworkTooltip = styled(Tooltip)`
+  &&& {
+    width: 100%;
+    border-radius: 5px;
+    background: #123952E5;
+    color: white;
+    padding: 16px;
+  }
+`
+
 function truncate(filename:string, max:number) {
   var extension = filename.substring(filename.lastIndexOf('.') + 1, filename.length);
   var base_name = filename.replace('.' + extension, '');
@@ -95,6 +107,7 @@ export type ArtworkProps = {
   date?:string,
   edit?:boolean,
   noTruncate?:boolean,
+  showTooltip?: boolean,
   onClick?:React.MouseEventHandler<HTMLDivElement>,
   onEdit?:Function|VoidFunction,
   onDelete?:Function|VoidFunction,
@@ -138,8 +151,13 @@ export const Artwork = ({
             />}
          <Button size="small" style={{height:"100%", marginLeft: 10, paddingRight: 4, paddingLeft: 4}} onClick={() => props.onSave!()}>Save</Button>
        </div> : props.name ?
-       <ArtworkName>{props.noTruncate ? props.name : truncate(props.name, 20)}</ArtworkName> : null}
-       {!props.edit && props.date ?
+       <ArtworkName data-tooltip-id={`artwork-tooltip-${props.name}`}>{props.noTruncate ? props.name : truncate(props.name, 20)}</ArtworkName> : null}
+      {props.showTooltip &&
+        (<ArtworkTooltip id={`artwork-tooltip-${props.name}`} place='top'>
+            {props.name}
+        </ArtworkTooltip>
+      )}
+      {!props.edit && props.date ?
        <UpdateDate>Updated {props.date}</UpdateDate> : null}
     </ArtworkInfo>
   </ArtworkWrapper>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4992,7 +4992,8 @@ const App = () => {
                     </Col>
                     <Col padded xs={3}>
                       <Artwork
-                        noTruncate
+                        noTruncate={false}
+                        showTooltip={true}
                         date="Jan 3 2020"
                         name="long name very long name really e very long name really e such a very very long namelong name such a very very long name squirrel.png"
                         picture={product_narrow}


### PR DESCRIPTION
https://commonsku.atlassian.net/browse/CORE-1136
- add the ability to show a tooltip for the truncated file name
![Screenshot 2025-04-28 at 2 14 28 PM](https://github.com/user-attachments/assets/4bf09d5b-3e8d-4452-9786-c16f0687acdc)
